### PR TITLE
Convert tests to Unix path separator

### DIFF
--- a/Tests/get common root of file paths.cpp
+++ b/Tests/get common root of file paths.cpp
@@ -3,17 +3,17 @@ using namespace okra;
 using namespace okra::internals;
 
 Example("common root of two related paths") {
-  auto result = get_common_root({R"(C:\foo\bar.cpp)", R"(C:\foo\qux\baz.cpp)"});
-  AssertEqual(result, R"(C:\foo)");
+  auto result = get_common_root({R"(/foo/bar.cpp)", R"(/foo/qux/baz.cpp)"});
+  AssertEqual(result, R"(/foo)");
 }
 
 Example("same path just returns directory") {
-  auto result = get_common_root({R"(C:\foo\bar.cpp)",
-                                 R"(C:\foo\bar.cpp)"});
-  AssertEqual(result, R"(C:\foo)");
+  auto result = get_common_root({R"(/foo/bar.cpp)",
+                                 R"(/foo/bar.cpp)"});
+  AssertEqual(result, R"(/foo)");
 }
 
 Example("common root of vector of paths") {
-  auto result = get_common_root({R"(C:\foo\bar.cpp)", R"(C:\foo\qux\baz.cpp)"});
-  AssertEqual(result, R"(C:\foo)");
+  auto result = get_common_root({R"(/foo/bar.cpp)", R"(/foo/qux/baz.cpp)"});
+  AssertEqual(result, R"(/foo)");
 }


### PR DESCRIPTION
When run on Unix, path::remove_filename() doesn't know what to do with
Windows-style paths.
To fix, convert the tests to use Unix-style paths.

This fixes issue #26.