### PR TITLE
Fix output of failing test

### DIFF
--- a/Okra.h
+++ b/Okra.h
@@ -15,7 +15,7 @@ namespace okra {
 template <class T, class U>
 void AssertEqual_(const T &t, const U &u, std::string message) {
   if (t != u) {
-    std::cout << message << " - assert FAILED - " << t << " != " << u
+    std::cout << ": " << message << " - assert FAILED - " << t << " != " << u
               << std::endl;
   }
 }


### PR DESCRIPTION
Need something between the test name and the failure info.
Added ": ".

Before fix:

    "format path for display" - the name of the test is based on the pathresult == R"(ux\baz)" - assert FAILED - "qux\\baz" != ux\baz

After fix:

    "format path for display" - the name of the test is based on the path: result == R"(ux\baz)" - assert FAILED - "qux\\baz" != ux\baz