### PR TITLE
Add timer output to test results

### DIFF
--- a/Okra.h
+++ b/Okra.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <chrono>
 #include <functional>
 #include <iostream>
 #include <iterator>
@@ -51,6 +52,13 @@ get_test_name_from_path(const std::experimental::filesystem::path &base,
       file.replace_extension().string().substr(base.string().length()));
 }
 
+long long time_to_execute_microseconds(const std::function<void(void)>& operation) {
+    auto begin = std::chrono::high_resolution_clock::now();
+    operation();
+    auto end = std::chrono::high_resolution_clock::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
+}
+
 struct Example {
   std::experimental::filesystem::path file;
   std::string name;
@@ -58,10 +66,8 @@ struct Example {
 
   void Run(std::experimental::filesystem::path base) const {
     std::cout << get_test_name_from_path(base, file) << " - " << name;
-    auto begin = std::chrono::high_resolution_clock::now();
-    body();
-    auto end = std::chrono::high_resolution_clock::now();
-    std::cout << " (" << std::chrono::duration_cast<std::chrono::microseconds>(end-begin).count() / 1000.0 << " ms)" << std::endl;
+    auto execution_time_ms = time_to_execute_microseconds(body) / 1000.0;
+    std::cout << " (" << execution_time_ms << " ms)" << std::endl;
   }
 };
 

--- a/Okra.h
+++ b/Okra.h
@@ -58,8 +58,10 @@ struct Example {
 
   void Run(std::experimental::filesystem::path base) const {
     std::cout << get_test_name_from_path(base, file) << " - " << name;
+    auto begin = std::chrono::high_resolution_clock::now();
     body();
-    std::cout << std::endl;
+    auto end = std::chrono::high_resolution_clock::now();
+    std::cout << " (" << std::chrono::duration_cast<std::chrono::microseconds>(end-begin).count() / 1000.0 << " ms)" << std::endl;
   }
 };
 

--- a/Okra.h
+++ b/Okra.h
@@ -52,10 +52,11 @@ get_test_name_from_path(const std::experimental::filesystem::path &base,
       file.replace_extension().string().substr(base.string().length()));
 }
 
+template <typename TClock>
 long long time_to_execute_microseconds(const std::function<void(void)>& operation) {
-    auto begin = std::chrono::high_resolution_clock::now();
+    auto begin = TClock::now();
     operation();
-    auto end = std::chrono::high_resolution_clock::now();
+    auto end = TClock::now();
     return std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count();
 }
 
@@ -66,7 +67,7 @@ struct Example {
 
   void Run(std::experimental::filesystem::path base) const {
     std::cout << get_test_name_from_path(base, file) << " - " << name;
-    auto execution_time_ms = time_to_execute_microseconds(body) / 1000.0;
+    auto execution_time_ms = time_to_execute_microseconds<std::chrono::high_resolution_clock>(body) / 1000.0;
     std::cout << " (" << execution_time_ms << " ms)" << std::endl;
   }
 };

--- a/Tests/get elapsed time of test.cpp
+++ b/Tests/get elapsed time of test.cpp
@@ -32,3 +32,11 @@ Example("the body of a test that takes no time is timed correctly") {
     AssertEqual(time_to_execute_microseconds<Clock>([](){}), 0);
 }
 
+Example("the body of a test that takes < 1 ms time is timed correctly") {
+    AssertEqual(time_to_execute_microseconds<Clock>([](){Clock::advance(std::chrono::microseconds(100));}), 100);
+}
+
+Example("the body of a test that takes > 1 ms time is timed correctly") {
+    AssertEqual(time_to_execute_microseconds<Clock>([](){Clock::advance(std::chrono::microseconds(1009));}), 1009);
+}
+

--- a/Tests/get elapsed time of test.cpp
+++ b/Tests/get elapsed time of test.cpp
@@ -1,0 +1,34 @@
+#include "Okra.h"
+#include <chrono>
+
+using namespace okra;
+using namespace okra::internals;
+
+class Clock {
+    public:
+        using rep = uint64_t;
+        using period = std::ratio<1, 1000000>;
+        using duration = std::chrono::duration<rep, period>;
+        using time_point = std::chrono::time_point<Clock>;
+
+        static void advance(duration d) noexcept {
+            nowMicroseconds += d;
+        }
+        static void reset_to_epoch() noexcept;
+        static time_point now() noexcept {
+            return nowMicroseconds;
+        }
+
+        static const bool is_steady;
+
+    private:
+        static time_point nowMicroseconds;
+};
+
+Clock::time_point Clock::nowMicroseconds;
+const bool Clock::is_steady = false;
+
+Example("the body of a test that takes no time is timed correctly") {
+    AssertEqual(time_to_execute_microseconds<Clock>([](){}), 0);
+}
+

--- a/Tests/get elapsed time of test.cpp
+++ b/Tests/get elapsed time of test.cpp
@@ -14,7 +14,6 @@ class Clock {
         static void advance(duration d) noexcept {
             nowMicroseconds += d;
         }
-        static void reset_to_epoch() noexcept;
         static time_point now() noexcept {
             return nowMicroseconds;
         }


### PR DESCRIPTION
Prints ms to 3 decimal places, like:

    $ ./get_common_root_of_file_paths 
    "/get common root of file paths" - common root of two related paths (0.037 ms)
    "/get common root of file paths" - same path just returns directory (0.029 ms)
    "/get common root of file paths" - common root of vector of paths (0.029 ms)

Could get fancy later by dropping precision if the values get larger or something.
